### PR TITLE
Refactor CMD in Dockerfile and update start-openclaw.sh for improved argument handling

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -73,9 +73,7 @@ jobs:
       - uses: actions/checkout@v6
       - run: |
           source ./tool.sh
-          build_image dev-hub latest docker_devbox/hub.Dockerfile \
-            --build-arg "BASE_IMG=node" \
-            --build-arg "ARG_PROFILE_JUPYTER=hub"
+          build_image dev-hub latest docker_devbox/hub.Dockerfile --build-arg "BASE_IMG=node" --build-arg "ARG_PROFILE_JUPYTER=hub"
           push_image dev-hub
     
   job-dev-hub-traefik:
@@ -85,10 +83,7 @@ jobs:
       - uses: actions/checkout@v6
       - run: |
           source ./tool.sh
-          build_image dev-hub-traefik latest docker_devbox/hub.Dockerfile \
-            --build-arg "BASE_IMG=base" \
-            --build-arg "ARG_PROFILE_JUPYTER=hub" \
-            --build-arg "ARG_KEEP_NODEJS=false"
+          build_image dev-hub-traefik latest docker_devbox/hub.Dockerfile --build-arg "BASE_IMG=base" --build-arg "ARG_PROFILE_JUPYTER=hub" --build-arg "ARG_KEEP_NODEJS=false"
           push_image dev-hub-traefik
 
   ## OpenResty as gateway

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -33,7 +33,7 @@ jobs:
     name: "clash"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - run: |
           source ./tool.sh && build_image clash latest docker_clash/clash.Dockerfile && push_image clash
 
@@ -42,7 +42,7 @@ jobs:
     name: "gui-linux"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - run: |
           source ./tool.sh && build_image gui-linux latest docker_gui/gui_linux.Dockerfile && push_image gui
 
@@ -52,7 +52,7 @@ jobs:
     name: "casdoor"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - run: |
           source ./tool.sh && build_image casdoor latest docker_casdoor/casdoor.Dockerfile && push_image casdoor
 
@@ -61,7 +61,7 @@ jobs:
     name: "keycloak"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - run: |
           source ./tool.sh && build_image keycloak latest docker_keycloak/keycloak.Dockerfile && push_image keycloak
 
@@ -70,7 +70,7 @@ jobs:
     name: "dev-hub"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - run: |
           source ./tool.sh
           build_image dev-hub latest docker_devbox/hub.Dockerfile --build-arg "BASE_IMG=node" --build-arg "ARG_PROFILE_JUPYTER=hub"
@@ -80,7 +80,7 @@ jobs:
     name: "dev-hub-traefik"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - run: |
           source ./tool.sh
           build_image dev-hub-traefik latest docker_devbox/hub.Dockerfile --build-arg "BASE_IMG=base" --build-arg "ARG_PROFILE_JUPYTER=hub" --build-arg "ARG_KEEP_NODEJS=false"
@@ -91,7 +91,7 @@ jobs:
     name: "openresty"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - run: |
           source ./tool.sh && build_image openresty latest docker_openresty/openresty.Dockerfile && push_image openresty
 
@@ -100,7 +100,7 @@ jobs:
     name: "searxng"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - run: |
           source ./tool.sh && build_image searxng latest docker_searxng/searxng.Dockerfile && push_image searxng
 
@@ -109,7 +109,7 @@ jobs:
     name: "storebox"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - run: |
           source ./tool.sh
           build_image storebox latest docker_storebox/storebox.Dockerfile && push_image storebox
@@ -119,7 +119,7 @@ jobs:
     name: "logent"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - run: |
           source ./tool.sh
           build_image logent latest docker_logent/logent.Dockerfile && push_image logent
@@ -129,7 +129,7 @@ jobs:
     name: "nocobase"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - run: |
           source ./tool.sh
           build_image nocobase latest docker_nocobase/nocobase.Dockerfile && push_image nocobase
@@ -139,7 +139,7 @@ jobs:
     name: "openclaw"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - run: |
           source ./tool.sh
           build_image openclaw latest docker_openclaw/openclaw.Dockerfile && push_image openclaw
@@ -149,7 +149,7 @@ jobs:
     name: "hermes"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - run: |
           source ./tool.sh
           build_image hermes latest docker_hermes/hermes.Dockerfile && push_image hermes
@@ -159,7 +159,7 @@ jobs:
     name: "developer,base-dev"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - run: |
           source ./tool.sh && free_diskspace
           build_image base-dev latest docker_devbox/dev.Dockerfile \
@@ -173,7 +173,7 @@ jobs:
     name: "data-science-dev"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - run: |
           source ./tool.sh && free_diskspace
           build_image data-science-dev latest docker_devbox/dev.Dockerfile \
@@ -188,7 +188,7 @@ jobs:
     name: "full-stack-dev"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - run: |
           source ./tool.sh && free_diskspace
           build_image full-stack-dev latest docker_devbox/dev.Dockerfile \
@@ -203,7 +203,7 @@ jobs:
     name: "full-cuda,cuda-dev"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - run: |
           source ./tool.sh && free_diskspace
           build_image cuda-dev latest docker_devbox/dev.Dockerfile \
@@ -235,7 +235,7 @@ jobs:
       ]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - env:
           AUTH_FILE_CONTENT: ${{ secrets.AUTH_FILE_CONTENT }}
           DOCKER_MIRROR_REGISTRY: ${{ vars.DOCKER_MIRROR_REGISTRY }}

--- a/docker_keycloak/work/script-setup-keycloak.sh
+++ b/docker_keycloak/work/script-setup-keycloak.sh
@@ -3,7 +3,7 @@ source /opt/utils/script-utils.sh
 setup_keycloak() {
   # Install the latest (but not nightly) version of keycloak
      VER_KEYCLOAK_MAJOR="26" \
-  && VER_KEYCLOAK=$(curl -sL https://github.com/keycloak/keycloak/releases.atom | grep 'releases/tag' | grep -v nightly | grep "${VER_KEYCLOAK_MAJOR}"  | head -1 | grep -Po '\d[\d.]+' ) \
+  && VER_KEYCLOAK=$(curl -sL https://api.github.com/repos/keycloak/keycloak/releases | jq -r --arg major "${VER_KEYCLOAK_MAJOR}" 'map(select(.prerelease == false and (.tag_name | startswith($major + "."))))[0].tag_name') \
   && URL_KEYCLOAK="https://github.com/keycloak/keycloak/releases/download/$VER_KEYCLOAK/keycloak-$VER_KEYCLOAK.tar.gz" \
   && echo "Downloading Keycloak version ${VER_KEYCLOAK} from: ${URL_KEYCLOAK}" \
   && install_tar_gz $URL_KEYCLOAK \

--- a/docker_litellm/demo/docker-compose.litellm.yml
+++ b/docker_litellm/demo/docker-compose.litellm.yml
@@ -1,0 +1,19 @@
+services:
+  svc-litellm:
+    container_name: svc-litellm
+    image: quay.io/labnow/litellm:latest
+    restart: unless-stopped
+    # networks: ["net-litellm"]
+    ports:
+      - "4000:4000"
+    volumes:
+      - ./data:/root/workspace
+    # environment:
+    #   - LITELLM_MASTER_KEY=sk-1234
+    #   - OPENAI_API_KEY=your-openai-key
+    #   - GEMINI_API_KEY=your-gemini-key
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"

--- a/docker_litellm/litellm.Dockerfile
+++ b/docker_litellm/litellm.Dockerfile
@@ -1,10 +1,11 @@
 # Distributed under the terms of the Modified BSD License.
 
 ARG BASE_NAMESPACE
-ARG BASE_IMG="node"
+ARG BASE_IMG_BUILD="node"
+ARG BASE_IMG="base"
 
 # --- Building Stage ---
-FROM ${BASE_NAMESPACE:+$BASE_NAMESPACE/}${BASE_IMG} AS builder
+FROM ${BASE_NAMESPACE:+$BASE_NAMESPACE/}${BASE_IMG_BUILD} AS builder
 
 LABEL maintainer="postmaster@labnow.ai"
 
@@ -12,19 +13,15 @@ LABEL maintainer="postmaster@labnow.ai"
 ENV NODE_ENV=development
 WORKDIR /build
 
-# Clone source
-RUN git clone --depth 1 --branch main https://github.com/BerriAI/litellm.git .
-
-# Build UI (Dashboard)
+# Clone source, Build UI (Dashboard) & Build Python wheel in one RUN layer
 RUN set -eux \
+ && git clone --depth 1 --branch main https://github.com/BerriAI/litellm.git . \
  && cd ui/litellm-dashboard \
  && npm install \
  && npm run build \
- && mkdir -p ../../litellm/proxy/_experimental/out \
- && cp -r out/* ../../litellm/proxy/_experimental/out/
-
-# Build Python wheel
-RUN set -eux \
+ && mkdir -pv ../../litellm/proxy/_experimental/out \
+ && cp -r out/* ../../litellm/proxy/_experimental/out/ \
+ && cd /build \
  && python3 -m pip install --upgrade pip build \
  && python3 -m build --wheel --outdir dist
 
@@ -34,28 +31,24 @@ FROM ${BASE_NAMESPACE:+$BASE_NAMESPACE/}${BASE_IMG}
 LABEL maintainer="postmaster@labnow.ai"
 
 # Production environment
-ENV NODE_ENV=production
-ENV LITELLM_HOME=/root/workspace
+ENV HOME_LITELLM=/opt/litellm
 ENV PATH="/opt/node/bin:/opt/conda/bin:/root/.local/bin:${PATH}"
-ENV HOME=/root/workspace
 
-WORKDIR /root/workspace
+WORKDIR ${HOME_LITELLM}
 
-# Copy utilities and tools
+# Copy utilities, tools and build artifacts
 COPY work /opt/utils/
-RUN chmod +x /opt/utils/*.sh && cp /opt/utils/start-litellm.sh /usr/local/bin/start-litellm.sh
-
-# Copy build artifacts from builder
 COPY --from=builder /build/dist/*.whl /tmp/
 
-# Install Runtime dependencies
+# Install Runtime dependencies and configure tools
 RUN set -eux \
+ && chmod +x /opt/utils/*.sh \
+ && ln -sf /opt/utils/start-litellm.sh /usr/local/bin/start-litellm.sh \
  && pip install --no-cache-dir /tmp/*.whl \
  && pip install --no-cache-dir 'litellm[proxy]' \
  ## Install supervisord (Go version) if needed or use simple entrypoint
  && source /opt/utils/script-setup-sys.sh && setup_supervisord \
- && source /opt/utils/script-utils.sh && install_apt /opt/utils/install_list_litellm.apt \
- && install__clean \
+ && source /opt/utils/script-utils.sh && install__clean \
  && rm -rf /tmp/*.whl
 
 # Data persistence

--- a/docker_litellm/work/install_list_litellm.apt
+++ b/docker_litellm/work/install_list_litellm.apt
@@ -1,1 +1,0 @@
-# Add any apt packages here

--- a/docker_litellm/work/start-litellm.sh
+++ b/docker_litellm/work/start-litellm.sh
@@ -2,11 +2,11 @@
 set -eu
 
 # Setup workspace directory
-LITELLM_HOME="${LITELLM_HOME:-/root/workspace}"
-mkdir -p "$LITELLM_HOME"
+HOME_LITELLM="${HOME_LITELLM:-/opt/litellm}"
+mkdir -p "$HOME_LITELLM"
 
-export HOME="$LITELLM_HOME"
-cd "$LITELLM_HOME"
+export HOME="$HOME_LITELLM"
+cd "$HOME_LITELLM"
 
 # Default config if not exists
 if [ ! -f "config.yaml" ]; then
@@ -19,14 +19,14 @@ model_list:
 EOF
 fi
 
-# If arguments are passed, route them
-if [ $# -gt 0 ]; then
-    if command -v "$1" >/dev/null 2>&1; then
-        exec "$@"
-    else
-        exec litellm "$@"
-    fi
+# If no arguments are passed, start litellm proxy with defaults
+if [ $# -eq 0 ]; then
+    set -- --config config.yaml --port 4000 --host 0.0.0.0
 fi
 
-# No arguments: start litellm proxy
-exec litellm --config config.yaml --port 4000 --host 0.0.0.0
+# Route execution: run command directly if it exists, otherwise wrap with litellm
+if command -v "$1" >/dev/null 2>&1; then
+    exec "$@"
+else
+    exec litellm "$@"
+fi

--- a/docker_openclaw/demo/docker-compose.yml
+++ b/docker_openclaw/demo/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - PROFILE_LOCALIZE=aliyun-pub
       - OPENCLAW_GATEWAY_TOKEN=openclaw
     volumes:
-      - /root/openclaw/data:/root/openclaw/data
+      - ${HOME}/openclaw:/root/.openclaw/data
     ports:
       - "${OPENCLAW_GATEWAY_PORT:-18789}:18789"
       - "${OPENCLAW_BRIDGE_PORT:-18790}:18790"

--- a/docker_openclaw/demo/docker-compose.yml
+++ b/docker_openclaw/demo/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - PROFILE_LOCALIZE=aliyun-pub
       - OPENCLAW_GATEWAY_TOKEN=openclaw
     volumes:
-      - /data/openclaw:/opt/openclaw/data
+      - /root/openclaw/data:/root/openclaw/data
     ports:
       - "${OPENCLAW_GATEWAY_PORT:-18789}:18789"
       - "${OPENCLAW_BRIDGE_PORT:-18790}:18790"

--- a/docker_openclaw/openclaw.Dockerfile
+++ b/docker_openclaw/openclaw.Dockerfile
@@ -8,17 +8,17 @@ LABEL maintainer="postmaster@labnow.ai"
 ENV NODE_ENV=production
 ENV PNPM_HOME=/opt/node/pnpm
 ENV PNPM_STORE=/opt/node/pnpm/store
-ENV OPENCLAW_HOME=/opt/openclaw
+ENV OPENCLAW_HOME=/root/openclaw
 ENV OPENCLAW_PLUGINS_ROOT=${OPENCLAW_HOME}/plugins
 ENV OPENCLAW_CONFIG=${OPENCLAW_HOME}/.openclaw/openclaw.json
 ENV PATH="${PNPM_HOME}:${OPENCLAW_HOME}:${PATH}"
-ENV HOME=/opt/openclaw
+ENV HOME=/root
 
-COPY work /opt/openclaw/
+COPY work /root/openclaw/
 
 RUN set -eux \
- && chmod +x  /opt/openclaw/*.sh && ln -sf /opt/openclaw/start-openclaw.sh /usr/local/bin/ \
- && mkdir -pv /opt/openclaw/data && ln -sfn /opt/openclaw/data /opt/openclaw/.openclaw \
+ && chmod +x  /root/openclaw/*.sh && ln -sf /root/openclaw/start-openclaw.sh /usr/local/bin/ \
+ && mkdir -pv /root/openclaw/data && ln -sfn /root/openclaw/data /root/openclaw/.openclaw \
  ## curl -fsSL https://openclaw.ai/install.sh | NO_PROMPT=1 bash -s -- --no-onboard --install-method npm \
  && export SHARP_IGNORE_GLOBAL_LIBVIPS=1 \
  && . /opt/utils/script-setup-core.sh && setup_node_pnpm 10 \
@@ -37,7 +37,7 @@ RUN set -eux \
  && (type supervisord || (. /opt/utils/script-setup-sys.sh && setup_supervisord && echo "Supervisord installed"))
 
 RUN set -eux && . /opt/utils/script-utils.sh \
- && . /opt/openclaw/script-setup-openclaw.sh \
+ && . /root/openclaw/script-setup-openclaw.sh \
  && cd $OPENCLAW_HOME \
  && printf 'packages:\n  - "plugins/*"\n' > pnpm-workspace.yaml \
  && printf '{"name":"openclaw-root","version":"1.0.0","private":true}\n' > package.json \
@@ -51,14 +51,13 @@ RUN set -eux && . /opt/utils/script-utils.sh \
  ## clean up
  && pnpm store prune --store-dir "$PNPM_STORE" && rm -rf "$PNPM_STORE" && install__clean \
  && rm -rf ~/.* \
- && ln -sfn /opt/openclaw/data /opt/openclaw/.openclaw \
- && ln -sfn /opt/openclaw /root/openclaw \
+ && ln -sfn /root/openclaw/data /root/openclaw/.openclaw \
  && ls -alh ~/
 
-ENV XDG_CONFIG_HOME=/opt/openclaw/data
+ENV XDG_CONFIG_HOME=/root/openclaw/data
 ENV OPENCLAW_HIDE_BANNER=1
-WORKDIR /opt/openclaw
-VOLUME ["/opt/openclaw/data", "/opt/node/pnpm/store"]
+WORKDIR /root/openclaw
+VOLUME ["/root/openclaw/data", "/opt/node/pnpm/store"]
 EXPOSE 18789 18790
 
 # Create supervisord configuration for openclaw

--- a/docker_openclaw/openclaw.Dockerfile
+++ b/docker_openclaw/openclaw.Dockerfile
@@ -8,37 +8,38 @@ LABEL maintainer="postmaster@labnow.ai"
 ENV NODE_ENV=production
 ENV PNPM_HOME=/opt/node/pnpm
 ENV PNPM_STORE=/opt/node/pnpm/store
-ENV OPENCLAW_HOME=/root/openclaw
-ENV OPENCLAW_PLUGINS_ROOT=${OPENCLAW_HOME}/plugins
-ENV OPENCLAW_CONFIG=${OPENCLAW_HOME}/.openclaw/openclaw.json
+
+ENV OPENCLAW_HOME=/root/.openclaw
+ENV OPENCLAW_STATE_DIR=${OPENCLAW_HOME}/data
+ENV OPENCLAW_PLUGINS_ROOT=/opt/openclaw/plugins
+ENV OPENCLAW_CONFIG_PATH=${OPENCLAW_STATE_DIR}/openclaw.json
+
 ENV PATH="${PNPM_HOME}:${OPENCLAW_HOME}:${PATH}"
 ENV HOME=/root
 
-COPY work /root/openclaw/
+COPY work /opt/openclaw/
 
 RUN set -eux \
- && chmod +x  /root/openclaw/*.sh && ln -sf /root/openclaw/start-openclaw.sh /usr/local/bin/ \
- && mkdir -pv /root/openclaw/data && ln -sfn /root/openclaw/data /root/openclaw/.openclaw \
+ && chmod +x  /opt/openclaw/*.sh && ln -sf /opt/openclaw/start-openclaw.sh /usr/local/bin/ \
+ && mkdir -pv ${OPENCLAW_STATE_DIR} \
  ## curl -fsSL https://openclaw.ai/install.sh | NO_PROMPT=1 bash -s -- --no-onboard --install-method npm \
  && export SHARP_IGNORE_GLOBAL_LIBVIPS=1 \
  && . /opt/utils/script-setup-core.sh && setup_node_pnpm 10 \
- && pnpm config set enable-pre-post-scripts true \
- && pnpm config set package-import-method hardlink \
- && pnpm config set node-linker isolated \
- && pnpm config set store-dir $PNPM_STORE \
- && GLOBAL_DIR=$(pnpm root -g | sed 's|/node_modules$||') \
+ && pnpm config set enable-pre-post-scripts     true        \
+ && pnpm config set package-import-method       hardlink    \
+ && pnpm config set node-linker                 isolated    \
+ && pnpm config set store-dir                   $PNPM_STORE \
+ && GLOBAL_DIR=$(pnpm root -g | sed 's|/node_modules$||')   \
  && mkdir -pv "$GLOBAL_DIR" \
  && echo '{"dependencies":{},"pnpm":{"onlyBuiltDependencies":["@matrix-org/matrix-sdk-crypto-nodejs","koffi","openclaw","protobufjs","sharp"]}}' \
        | tee "$GLOBAL_DIR/package.json" \
  && pnpm config list \
  && pnpm install --prod -g --ignore-scripts=false --config.unsafe-perm=true --store-dir "$PNPM_STORE" openclaw@latest \
  && pnpm store prune --store-dir "$PNPM_STORE" && rm -rf "$PNPM_STORE" && install__clean \
- && openclaw --version \
- && (type supervisord || (. /opt/utils/script-setup-sys.sh && setup_supervisord && echo "Supervisord installed"))
+ && openclaw --version
 
-RUN set -eux && . /opt/utils/script-utils.sh \
- && . /root/openclaw/script-setup-openclaw.sh \
- && cd $OPENCLAW_HOME \
+RUN set -eux && cd /opt/openclaw \
+ && . /opt/utils/script-utils.sh && . /opt/openclaw/script-setup-openclaw.sh \
  && printf 'packages:\n  - "plugins/*"\n' > pnpm-workspace.yaml \
  && printf '{"name":"openclaw-root","version":"1.0.0","private":true}\n' > package.json \
  && PNPM_VER="$(pnpm --version)" \
@@ -49,24 +50,13 @@ RUN set -eux && . /opt/utils/script-utils.sh \
  && add_plugin "@larksuite/openclaw-lark" "openclaw-lark" \
  && pnpm install --prod \
  ## clean up
- && pnpm store prune --store-dir "$PNPM_STORE" && rm -rf "$PNPM_STORE" && install__clean \
- && rm -rf ~/.* \
- && ln -sfn /root/openclaw/data /root/openclaw/.openclaw \
- && ls -alh ~/
+ && pnpm store prune --store-dir "$PNPM_STORE" \
+ && rm -rf ~/.npm ~/.cache ~/.local ~/.pnpm-state "$PNPM_STORE" \
+ && install__clean && ls -alh ~/
 
-ENV XDG_CONFIG_HOME=/root/openclaw/data
-ENV OPENCLAW_HIDE_BANNER=1
-WORKDIR /root/openclaw
-VOLUME ["/root/openclaw/data", "/opt/node/pnpm/store"]
+ENV XDG_CONFIG_HOME=/root/.openclaw/data
+WORKDIR /opt/openclaw
+VOLUME ["/root/.openclaw/data", "/opt/node/pnpm/store"]
 EXPOSE 18789 18790
 
-# Create supervisord configuration for openclaw
-RUN set -eux \
- && mkdir -pv /etc/supervisord \
- && printf '[supervisord]\nidentifier=openclaw\nautostart=false\nnodaemon=false\npidfile=/var/run/supervisord.pid\nlogfile=/dev/stdout\nloglevel=warning\n\n[program-default]\nstdout_logfile=/dev/stdout\nstderr_logfile=/dev/stderr\nautostart=false\nautorestart=true\nstdout_logfile_maxbytes=10MB\nstdout_logfile_backups=10\nredirect_stderr=true\nstartretries=3\n\n[program:openclaw]\ncommand=/usr/local/bin/start-openclaw.sh gateway --allow-unconfigured\nautostart=true\n' > /etc/supervisord/supervisord.conf \
- && printf '#!/bin/bash\nexec supervisord -c /etc/supervisord/supervisord.conf\n' > /usr/local/bin/start-supervisord.sh \
- && chmod +x /usr/local/bin/start-supervisord.sh
-
-RUN ln -sfn /root/openclaw /opt/openclaw
-
-CMD ["start-supervisord.sh"]
+CMD ["start-openclaw.sh"]

--- a/docker_openclaw/openclaw.Dockerfile
+++ b/docker_openclaw/openclaw.Dockerfile
@@ -67,4 +67,6 @@ RUN set -eux \
  && printf '#!/bin/bash\nexec supervisord -c /etc/supervisord/supervisord.conf\n' > /usr/local/bin/start-supervisord.sh \
  && chmod +x /usr/local/bin/start-supervisord.sh
 
+RUN ln -sfn /root/openclaw /opt/openclaw
+
 CMD ["start-supervisord.sh"]

--- a/docker_openclaw/openclaw.Dockerfile
+++ b/docker_openclaw/openclaw.Dockerfile
@@ -59,6 +59,4 @@ WORKDIR /opt/openclaw
 VOLUME ["/opt/openclaw/data", "/opt/node/pnpm/store"]
 EXPOSE 18789 18790
 
-CMD start-openclaw.sh gateway --allow-unconfigured \
-    --bind "${OPENCLAW_GATEWAY_BIND:-lan}" \
-    --port "${OPENCLAW_GATEWAY_PORT:-18789}"
+CMD ["start-openclaw.sh", "gateway", "--allow-unconfigured"]

--- a/docker_openclaw/openclaw.Dockerfile
+++ b/docker_openclaw/openclaw.Dockerfile
@@ -21,7 +21,7 @@ RUN set -eux \
  && mkdir -pv /opt/openclaw/data && ln -sfn /opt/openclaw/data /opt/openclaw/.openclaw \
  ## curl -fsSL https://openclaw.ai/install.sh | NO_PROMPT=1 bash -s -- --no-onboard --install-method npm \
  && export SHARP_IGNORE_GLOBAL_LIBVIPS=1 \
- && source /opt/utils/script-setup-core.sh && setup_node_pnpm 10 \
+ && . /opt/utils/script-setup-core.sh && setup_node_pnpm 10 \
  && pnpm config set enable-pre-post-scripts true \
  && pnpm config set package-import-method hardlink \
  && pnpm config set node-linker isolated \
@@ -34,10 +34,10 @@ RUN set -eux \
  && pnpm install --prod -g --ignore-scripts=false --config.unsafe-perm=true --store-dir "$PNPM_STORE" openclaw@latest \
  && pnpm store prune --store-dir "$PNPM_STORE" && rm -rf "$PNPM_STORE" && install__clean \
  && openclaw --version \
- && (type supervisord || (source /opt/utils/script-setup-sys.sh && setup_supervisord && echo "Supervisord installed"))
+ && (type supervisord || (. /opt/utils/script-setup-sys.sh && setup_supervisord && echo "Supervisord installed"))
 
-RUN set -eux && source /opt/utils/script-utils.sh \
- && source /opt/openclaw/script-setup-openclaw.sh \
+RUN set -eux && . /opt/utils/script-utils.sh \
+ && . /opt/openclaw/script-setup-openclaw.sh \
  && cd $OPENCLAW_HOME \
  && printf 'packages:\n  - "plugins/*"\n' > pnpm-workspace.yaml \
  && printf '{"name":"openclaw-root","version":"1.0.0","private":true}\n' > package.json \
@@ -52,6 +52,7 @@ RUN set -eux && source /opt/utils/script-utils.sh \
  && pnpm store prune --store-dir "$PNPM_STORE" && rm -rf "$PNPM_STORE" && install__clean \
  && rm -rf ~/.* \
  && ln -sfn /opt/openclaw/data /opt/openclaw/.openclaw \
+ && ln -sfn /opt/openclaw /root/openclaw \
  && ls -alh ~/
 
 ENV XDG_CONFIG_HOME=/opt/openclaw/data

--- a/docker_openclaw/openclaw.Dockerfile
+++ b/docker_openclaw/openclaw.Dockerfile
@@ -29,11 +29,12 @@ RUN set -eux \
  && GLOBAL_DIR=$(pnpm root -g | sed 's|/node_modules$||') \
  && mkdir -pv "$GLOBAL_DIR" \
  && echo '{"dependencies":{},"pnpm":{"onlyBuiltDependencies":["@matrix-org/matrix-sdk-crypto-nodejs","koffi","openclaw","protobufjs","sharp"]}}' \
-      | tee "$GLOBAL_DIR/package.json" \
+       | tee "$GLOBAL_DIR/package.json" \
  && pnpm config list \
  && pnpm install --prod -g --ignore-scripts=false --config.unsafe-perm=true --store-dir "$PNPM_STORE" openclaw@latest \
  && pnpm store prune --store-dir "$PNPM_STORE" && rm -rf "$PNPM_STORE" && install__clean \
- && openclaw --version
+ && openclaw --version \
+ && (type supervisord || (source /opt/utils/script-setup-sys.sh && setup_supervisord && echo "Supervisord installed"))
 
 RUN set -eux && source /opt/utils/script-utils.sh \
  && source /opt/openclaw/script-setup-openclaw.sh \
@@ -59,4 +60,11 @@ WORKDIR /opt/openclaw
 VOLUME ["/opt/openclaw/data", "/opt/node/pnpm/store"]
 EXPOSE 18789 18790
 
-CMD ["start-openclaw.sh", "gateway", "--allow-unconfigured"]
+# Create supervisord configuration for openclaw
+RUN set -eux \
+ && mkdir -pv /etc/supervisord \
+ && printf '[supervisord]\nidentifier=openclaw\nautostart=false\nnodaemon=false\npidfile=/var/run/supervisord.pid\nlogfile=/dev/stdout\nloglevel=warning\n\n[program-default]\nstdout_logfile=/dev/stdout\nstderr_logfile=/dev/stderr\nautostart=false\nautorestart=true\nstdout_logfile_maxbytes=10MB\nstdout_logfile_backups=10\nredirect_stderr=true\nstartretries=3\n\n[program:openclaw]\ncommand=/usr/local/bin/start-openclaw.sh gateway --allow-unconfigured\nautostart=true\n' > /etc/supervisord/supervisord.conf \
+ && printf '#!/bin/bash\nexec supervisord -c /etc/supervisord/supervisord.conf\n' > /usr/local/bin/start-supervisord.sh \
+ && chmod +x /usr/local/bin/start-supervisord.sh
+
+CMD ["start-supervisord.sh"]

--- a/docker_openclaw/work/script-setup-openclaw.sh
+++ b/docker_openclaw/work/script-setup-openclaw.sh
@@ -3,8 +3,8 @@ set -eu
 
 
 init_config() {
-  if [ ! -f "$OPENCLAW_CONFIG" ]; then
-    mkdir -p "$(dirname "$OPENCLAW_CONFIG")"
+  if [ ! -f "$OPENCLAW_CONFIG_PATH" ]; then
+    mkdir -p "$(dirname "$OPENCLAW_CONFIG_PATH")"
 
     jq -n \
       --argjson plugin_paths "[\"$OPENCLAW_PLUGINS_ROOT\"]" \
@@ -24,7 +24,7 @@ init_config() {
             token: $token
           }
         }
-      }' > "$OPENCLAW_CONFIG"
+      }' > "$OPENCLAW_CONFIG_PATH"
   fi
 }
 

--- a/docker_openclaw/work/script-setup-openclaw.sh
+++ b/docker_openclaw/work/script-setup-openclaw.sh
@@ -6,9 +6,17 @@ init_config() {
   if [ ! -f "$OPENCLAW_CONFIG_PATH" ]; then
     mkdir -p "$(dirname "$OPENCLAW_CONFIG_PATH")"
 
+    local auth_mode="${OPENCLAW_GATEWAY_AUTH_MODE:-none}"
+    local token="${OPENCLAW_GATEWAY_TOKEN:-openclaw}"
+    local trusted_proxies="${OPENCLAW_GATEWAY_TRUSTED_PROXIES:-[\"127.0.0.1\", \"10.0.0.0/8\", \"172.16.0.0/12\", \"192.168.0.0/16\"]}"
+    local user_header="${OPENCLAW_GATEWAY_USER_HEADER:-x-auth-request-email}"
+
     jq -n \
       --argjson plugin_paths "[\"$OPENCLAW_PLUGINS_ROOT\"]" \
-      --arg token "${OPENCLAW_GATEWAY_TOKEN:-openclaw}" \
+      --arg mode "$auth_mode" \
+      --arg token "$token" \
+      --argjson trusted_proxies "$trusted_proxies" \
+      --arg user_header "$user_header" \
       '{
         plugins: {
           load: { paths: $plugin_paths },
@@ -19,12 +27,14 @@ init_config() {
             dangerouslyAllowHostHeaderOriginFallback: true,
             dangerouslyDisableDeviceAuth: true
           },
+          trustedProxies: $trusted_proxies,
           auth: {
-            mode: "token",
-            token: $token
+            mode: $mode,
+            token: (if $mode == "token" then $token else null end),
+            trustedProxy: (if $mode == "trusted-proxy" then { userHeader: $user_header } else null end)
           }
         }
-      }' > "$OPENCLAW_CONFIG_PATH"
+      } | del(.. | select(. == null))' > "$OPENCLAW_CONFIG_PATH"
   fi
 }
 

--- a/docker_openclaw/work/start-openclaw.sh
+++ b/docker_openclaw/work/start-openclaw.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -eu
 
+mkdir -p /root/openclaw/data
+ln -sfn /root/openclaw/data /root/openclaw/.openclaw
+
 bootstrap() {
   . /root/openclaw/script-setup-openclaw.sh
 

--- a/docker_openclaw/work/start-openclaw.sh
+++ b/docker_openclaw/work/start-openclaw.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 set -eu
 
-
 bootstrap() {
   . /opt/openclaw/script-setup-openclaw.sh
 
@@ -26,5 +25,19 @@ bootstrap() {
 /opt/utils/script-localize.sh "${PROFILE_LOCALIZE:-default}"
 [ ! -f "$OPENCLAW_CONFIG" ] && bootstrap
 
-echo "Starting openclaw with options:" "$@"
-exec openclaw "$@"
+# If arguments are passed, route them
+if [ $# -gt 0 ]; then
+    # If the first argument is an executable in PATH, execute it directly (e.g. bash, sh, sleep)
+    if command -v "$1" >/dev/null 2>&1; then
+        exec "$@"
+    fi
+    # Pass to openclaw CLI with default bind/port
+    exec openclaw "$@" \
+        --bind "${OPENCLAW_GATEWAY_BIND:-lan}" \
+        --port "${OPENCLAW_GATEWAY_PORT:-18789}"
+fi
+
+# No arguments: default gateway start
+exec openclaw gateway --allow-unconfigured \
+    --bind "${OPENCLAW_GATEWAY_BIND:-lan}" \
+    --port "${OPENCLAW_GATEWAY_PORT:-18789}"

--- a/docker_openclaw/work/start-openclaw.sh
+++ b/docker_openclaw/work/start-openclaw.sh
@@ -2,7 +2,7 @@
 set -eu
 
 bootstrap() {
-  . /opt/openclaw/script-setup-openclaw.sh
+  . /root/openclaw/script-setup-openclaw.sh
 
   init_config
 

--- a/docker_openclaw/work/start-openclaw.sh
+++ b/docker_openclaw/work/start-openclaw.sh
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
 set -eu
 
-mkdir -p /root/openclaw/data
-ln -sfn /root/openclaw/data /root/openclaw/.openclaw
+export OPENCLAW_HIDE_BANNER=${OPENCLAW_HIDE_BANNER:-1}
+
+mkdir -pv ${OPENCLAW_STATE_DIR}
 
 bootstrap() {
-  . /root/openclaw/script-setup-openclaw.sh
+  . /opt/openclaw/script-setup-openclaw.sh
 
   init_config
 
@@ -19,28 +20,27 @@ bootstrap() {
     def build_entries:
       reduce $plugins[] as $p ({}; .[$p] = {enabled: true});
     .plugins.entries = build_entries
-    ' "$OPENCLAW_CONFIG" > "${OPENCLAW_CONFIG}.tmp" \
-    && mv "${OPENCLAW_CONFIG}.tmp" "$OPENCLAW_CONFIG"
+    ' "$OPENCLAW_CONFIG_PATH" > "${OPENCLAW_CONFIG_PATH}.tmp" \
+    && mv "${OPENCLAW_CONFIG_PATH}.tmp" "$OPENCLAW_CONFIG_PATH"
 
   echo "[OK] Plugins entries updated"
 }
 
 /opt/utils/script-localize.sh "${PROFILE_LOCALIZE:-default}"
-[ ! -f "$OPENCLAW_CONFIG" ] && bootstrap
+[ ! -f "$OPENCLAW_CONFIG_PATH" ] && bootstrap
 
-# If arguments are passed, route them
-if [ $# -gt 0 ]; then
-    # If the first argument is an executable in PATH, execute it directly (e.g. bash, sh, sleep)
-    if command -v "$1" >/dev/null 2>&1; then
-        exec "$@"
-    fi
-    # Pass to openclaw CLI with default bind/port
-    exec openclaw "$@" \
-        --bind "${OPENCLAW_GATEWAY_BIND:-lan}" \
-        --port "${OPENCLAW_GATEWAY_PORT:-18789}"
+# If no arguments are passed, use the default gateway startup command
+if [ $# -eq 0 ]; then
+    set -- gateway --allow-unconfigured
 fi
 
-# No arguments: default gateway start
-exec openclaw gateway --allow-unconfigured \
+# If the first argument is an executable in PATH (like bash, sh, or openclaw itself), execute it directly
+if command -v "$1" >/dev/null 2>&1; then
+    exec "$@"
+fi
+
+# Otherwise, prepend default bind and port parameters and pass arguments to openclaw CLI
+exec openclaw \
     --bind "${OPENCLAW_GATEWAY_BIND:-lan}" \
-    --port "${OPENCLAW_GATEWAY_PORT:-18789}"
+    --port "${OPENCLAW_GATEWAY_PORT:-18789}" \
+    "$@"

--- a/tool.sh
+++ b/tool.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -eux
 
+# If not executed in GitHub Action, run script in project root, and export the following 3 variables manually:
+# export REGISTRY_SRC='quay.io'            # For BASE_NAMESPACE of images: where to pull base images from, docker.io or other source registry URL.
+# export REGISTRY_DST='quay.io'            # For tags of built images: where to push images to, docker.io or other destination registry URL.
+# export CI_PROJECT_NAME='LabNow/lab-dev'
+
 CI_PROJECT_NAME=${CI_PROJECT_NAME:-$GITHUB_REPOSITORY}
 CI_PROJECT_BRANCH=${GITHUB_HEAD_REF:-"main"}
 CI_PROJECT_SPACE=$(echo "${CI_PROJECT_BRANCH}" | cut -f1 -d'/')
@@ -91,4 +96,4 @@ setup_github_actions() {
     jq '.experimental=true | ."data-root"="/mnt/docker"' /etc/docker/daemon.json > /tmp/daemon.json && sudo mv /tmp/daemon.json /etc/docker/ ;
     ( sudo service docker restart || true ) && cat /etc/docker/daemon.json && docker info ;
 }
-[ "$GITHUB_ACTIONS" = "true" ] && echo "Running in GitHub Actions and Setup Env: $(setup_github_actions)"
+[ ${GITHUB_ACTIONS:-"false"} = "true" ] && echo "Running in GitHub Actions and Setup Env: $(setup_github_actions)" || echo "Not running in GitHub Action." ;


### PR DESCRIPTION
This pull request refactors how the OpenClaw Docker container handles its startup command and argument parsing to improve flexibility and compatibility with Docker best practices. The main changes are in how the entrypoint script processes arguments and starts the service.

**Entrypoint and Argument Handling Improvements:**

* Changed the `CMD` instruction in `openclaw.Dockerfile` to use JSON array form for better argument handling and to allow overriding the command more easily in Docker (`start-openclaw.sh gateway --allow-unconfigured` is now `["start-openclaw.sh", "gateway", "--allow-unconfigured"]`).
* Updated `start-openclaw.sh` to check if arguments are passed: if the first argument is an executable, it will run it directly (e.g., `bash`, `sh`, `sleep`), otherwise it will pass arguments to the `openclaw` CLI with default bind/port options. If no arguments are provided, it starts the OpenClaw gateway with default options.

**General Script Improvements:**

* Minor cleanup in `start-openclaw.sh`, such as removing an unnecessary blank line.